### PR TITLE
Feat/cli label indices

### DIFF
--- a/huff_cli/src/huffc.rs
+++ b/huff_cli/src/huffc.rs
@@ -243,7 +243,7 @@ fn main() {
                         .join("\n  ");
 
                     println!("\n------ JUMP LABEL INDICES ------");
-                    println!("{}", format!("  {}", label_indices).to_string());
+                    println!("  {}", label_indices);
                     println!("--------------------------------\n")
                 } else {
                     eprintln!(

--- a/huff_cli/src/huffc.rs
+++ b/huff_cli/src/huffc.rs
@@ -238,7 +238,7 @@ fn main() {
                     let label_indices = bytecode_res
                         .label_indices
                         .iter()
-                        .map(|(label, index)| format!("{}: 0x{:04x}", label, index))
+                        .map(|(label, index)| format!("{}: {:#04x}", label, index))
                         .collect::<Vec<_>>()
                         .join("\n");
 

--- a/huff_cli/src/huffc.rs
+++ b/huff_cli/src/huffc.rs
@@ -160,12 +160,12 @@ fn main() {
                 // Check that constant override argument is valid
                 // Key rule: Alphabetic chars + underscore
                 // Value rule: Valid literal string (0x...)
-                if parts.len() != 2
-                    || parts[0].chars().any(|c| !(c.is_alphabetic() || c == '_'))
-                    || !parts[1].starts_with("0x")
-                    || parts[1][2..].chars().any(|c| {
-                        !(c.is_numeric()
-                            || matches!(c, '\u{0041}'..='\u{0046}' | '\u{0061}'..='\u{0066}'))
+                if parts.len() != 2 ||
+                    parts[0].chars().any(|c| !(c.is_alphabetic() || c == '_')) ||
+                    !parts[1].starts_with("0x") ||
+                    parts[1][2..].chars().any(|c| {
+                        !(c.is_numeric() ||
+                            matches!(c, '\u{0041}'..='\u{0046}' | '\u{0061}'..='\u{0066}'))
                     })
                 {
                     eprintln!("Invalid constant override argument: {}", Paint::red(c.to_string()));
@@ -257,7 +257,7 @@ fn main() {
                 std::process::exit(1);
             }
         }
-        return;
+        return
     }
 
     if let Some(TestCommands::Test { format, match_ }) = cli.test {
@@ -286,7 +286,7 @@ fn main() {
                 std::process::exit(1);
             }
         }
-        return;
+        return
     }
 
     // Create compiling spinner

--- a/huff_cli/src/huffc.rs
+++ b/huff_cli/src/huffc.rs
@@ -240,9 +240,11 @@ fn main() {
                         .iter()
                         .map(|(label, index)| format!("{}: {:#04x}", label, index))
                         .collect::<Vec<_>>()
-                        .join("\n");
+                        .join("\n  ");
 
-                    println!("Label indices:\n{}", label_indices);
+                    println!("\n------ JUMP LABEL INDICES ------");
+                    println!("{}", format!("  {}", label_indices).to_string());
+                    println!("--------------------------------\n")
                 } else {
                     eprintln!(
                         "{}",


### PR DESCRIPTION
## Overview

<!--
Thank you for creating a Pull Request!
Please provide a short description here and review the requirements below.
Bug fixes and new features should include tests.

Make sure to run these checks before opening a pr!
```sh
cargo check --all
cargo test --all --all-features
cargo +nightly fmt -- --check
cargo +nightly clippy --all --all-features -- -D warnings
```

Recommended method to auto format your code before pushing:
```sh
cargo +nightly fmt --all
```
-->

- WIP: added a `huff_cli` flag to print the jump label indices of the MAIN macro for a specified contract. A more complete version of this diff could be useful to generate a bytes32 packed jump table for use with a single-byte function dispatcher in order to fill it automatically. 